### PR TITLE
docs: Fix URL typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Introduction
 
-This is a Gatsby source plugin for building websites using the [Storyblok](htts://www.storyblok.com) headless CMS with true visual preview as a data source.
+This is a Gatsby source plugin for building websites using the [Storyblok](https://www.storyblok.com) headless CMS with true visual preview as a data source.
 
 ## How to install
 


### PR DESCRIPTION
Fix URL typo `htts://` to `https://`