### PR TITLE
Added homepage and repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,5 +23,7 @@
   },
   "peerDependencies": {
     "storyblok-react": "^0.0.6"
-  }
+  },
+  "homepage": "https://www.storyblok.com",
+  "repository": "https://github.com/storyblok/gatsby-source-storyblok",
 }


### PR DESCRIPTION
This adds links to homepage/repository on Gatsbyjs.org and NPM.

FYI: For some reason, the link to storyblok.com in README.md is not working on NPM (starts with htts instead of https). But it is correct on GitHub.

Edit: Now saw PR #2, but this needs to be published on NPM too.