### PR TITLE
Prevent unexpected transformation process

### DIFF
--- a/src/sync.js
+++ b/src/sync.js
@@ -50,7 +50,6 @@ module.exports = {
       parent: null,
       children: [],
       internal: {
-        mediaType: `application/json`,
         type: name,
         contentDigest: crypto.createHash(`md5`).update(stringify(item)).digest(`hex`)
       }
@@ -65,7 +64,6 @@ module.exports = {
       parent: null,
       children: [],
       internal: {
-        mediaType: `application/json`,
         type: name,
         contentDigest: crypto.createHash(`md5`).update(stringify(item)).digest(`hex`)
       }


### PR DESCRIPTION
Related to #19 .

What was happening? Like we defined our nodes as `application/json`, the `gatsby-transformer-json` plugin was trying to handle with our nodes. So, the solution is remove the mediaType statement to any transformer don't try to handle with our nodes.