### PR TITLE
Make Content object accessible via GraphQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ exports.createPages = async ({ graphql, actions }) => {
     version: 'draft',
     resolveRelations: [''],
     includeLinks: false
+    contentObject: true
   }
 }
 ```
@@ -109,6 +110,7 @@ exports.createPages = async ({ graphql, actions }) => {
 * `resolveLinks`: This will automatically resolve internal links of the multilink field type. If the value is `story` the whole story object will be included.  If the value is `url` only uuid, id, name, path, slug and url (url is a computed property which returns the "Real path" if defined to use it for navigation links) will be included. 
 * `resolveRelations`: Resolve relationships to other Stories (in the first level of nesting) of a multi-option or single-option field-type. Provide the field key(s) as array to resolve specific fields. Example: ['article.related_articles', 'article.author'].
 * `includeLinks`: If 'true' you can query links by allStoryblokLinkEntry. The links query lets you create a dynamic navigation tree as it includes also content folders.
+* `contentObject`: If 'true', the content for each story will be accessible via GraphQL. If 'false' or undefined, all content will be stringified.
 
 ## How to query?
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -39,6 +39,9 @@ exports.sourceNodes = async function({ boundActionCreators }, options) {
 
           item['field_' + prop + type] = item.content[prop]
         }
+        if(!options.contentObject) {
+          item.content = stringify(item.content)
+        }
       }
     })
   }

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -39,7 +39,6 @@ exports.sourceNodes = async function({ boundActionCreators }, options) {
 
           item['field_' + prop + type] = item.content[prop]
         }
-        item.content = stringify(item.content)
       }
     })
   }


### PR DESCRIPTION
Trying to use this in a project, but majority of my data is available as content within each story, and this content object is stringified, so I can't access and interact with the object properties separately via GraphQL.

Tested running this plugin locally without the stringify line and everything continues to run and work properly without it, and the content object  is now accessible via GraphQL.

So as not to break anyone's implementations, I've proposed an additional option, to allow users to choose if they want to stringify this data.