### PR TITLE
add possibility of only loading select languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ module.exports = {
       resolve: 'gatsby-source-storyblok',
       options: {
         accessToken: 'YOUR_TOKEN',
-        version: 'draft'
+        version: 'draft',
+        languages: ['de', 'at'] // Optional parameter. Omission will retrieve all languages by default.
       }
     }
   ]

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -5,7 +5,7 @@ const stringify = require('json-stringify-safe')
 
 exports.sourceNodes = async function({ boundActionCreators }, options) {
   const { createNode, setPluginStatus } = boundActionCreators;
-  const client = new StoryblokClient(options, 'https://mapi.storyblok.com/v1');
+  const client = new StoryblokClient(options, 'https://api.storyblok.com/v1');
 
   Sync.init({
     createNode,
@@ -14,7 +14,7 @@ exports.sourceNodes = async function({ boundActionCreators }, options) {
   })
 
   const space = await Sync.getSpace()
-  const languages = space.language_codes.map((lang) => { return lang + '/*' })
+  const languages = (options.languages ?? space.language_codes).map((lang) => { return lang + '/*' })
   languages.push('')
 
   for (const language of languages) {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -14,7 +14,7 @@ exports.sourceNodes = async function({ boundActionCreators }, options) {
   })
 
   const space = await Sync.getSpace()
-  const languages = (options.languages ?? space.language_codes).map((lang) => { return lang + '/*' })
+  const languages = (options.languages ? options.languages : space.language_codes).map((lang) => { return lang + '/*' })
   languages.push('')
 
   for (const language of languages) {

--- a/src/getStoryParams.js
+++ b/src/getStoryParams.js
@@ -26,10 +26,6 @@ const getStoryParams = function(language = '', options = {}) {
     params.language = options.language
   }
 
-  if (language.length > 0) {
-    params.starts_with = language
-  }
-
   return params
 }
 

--- a/src/getStoryParams.js
+++ b/src/getStoryParams.js
@@ -5,7 +5,6 @@
  * @param  {Array<String>} options.resolveRelations? resolve_relations field
  * @param  {String}        options.resolveLinks? can be story or url
  * @param  {String}        options.version? can be draft or released
- * @param  {String}        options.language? array of languages
  */
 const getStoryParams = function(language = '', options = {}) {
   let params = {}

--- a/src/getStoryParams.js
+++ b/src/getStoryParams.js
@@ -21,8 +21,8 @@ const getStoryParams = function(language = '', options = {}) {
     params.version = options.version
   }
 
-  if (options.language) {
-    params.language = options.language
+  if (language.length > 0) {
+    params.starts_with = language
   }
 
   return params

--- a/src/getStoryParams.js
+++ b/src/getStoryParams.js
@@ -5,6 +5,7 @@
  * @param  {Array<String>} options.resolveRelations? resolve_relations field
  * @param  {String}        options.resolveLinks? can be story or url
  * @param  {String}        options.version? can be draft or released
+ * @param  {String}        options.language? array of languages
  */
 const getStoryParams = function(language = '', options = {}) {
   let params = {}
@@ -19,6 +20,10 @@ const getStoryParams = function(language = '', options = {}) {
 
   if (options.version) {
     params.version = options.version
+  }
+
+  if (options.language) {
+    params.language = options.language
   }
 
   if (language.length > 0) {


### PR DESCRIPTION
I decided to add this because for my use case it improves the node loading times exponentially.
In case the option is ommited, behaviour is the same as before.
Since we have a huge amount of stories, with this change in development for example, I decreased the node building from 450s to 60s.

It's super useful when developing and also useful for multi site builds.

I also changed to `api.storyblok.com` instead of `mapi.storyblok.com`. This should also be faster according to storyblok documentation.

Please feel free to change the code or point out any mistakes I might have made.