### PR TITLE
FIX - Upgrade to Gatsby 3: Removal of boundActionCreators

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -3,8 +3,8 @@ const Sync = require('./src/sync')
 const getStoryParams = require('./src/getStoryParams')
 const stringify = require('json-stringify-safe')
 
-exports.sourceNodes = async function({ boundActionCreators }, options) {
-  const { createNode, setPluginStatus } = boundActionCreators;
+exports.sourceNodes = async function({ actions }, options) {
+  const { createNode, setPluginStatus } = actions;
   const client = new StoryblokClient(options, 'https://api.storyblok.com/v1');
 
   Sync.init({


### PR DESCRIPTION
Simple fix to be compatible with Gatsby v3.

See: https://www.gatsbyjs.com/docs/reference/release-notes/migrating-from-v2-to-v3#removal-of-boundactioncreators