### PR TITLE
added from_release option to getStoryParams with added test

### DIFF
--- a/src/getStoryParams.js
+++ b/src/getStoryParams.js
@@ -5,27 +5,32 @@
  * @param  {Array<String>} options.resolveRelations? resolve_relations field
  * @param  {String}        options.resolveLinks? can be story or url
  * @param  {String}        options.version? can be draft or released
+ * @param  {String}        options.fromRelease? from_release field
  */
-const getStoryParams = function(language = '', options = {}) {
-  let params = {}
+ const getStoryParams = function (language = '', options = {}) {
+  let params = {};
 
   if (options.resolveLinks) {
-    params.resolve_links = options.resolveLinks || '1'
+    params.resolve_links = options.resolveLinks || '1';
   }
 
   if (options.resolveRelations) {
-    params.resolve_relations = options.resolveRelations.join(',')
+    params.resolve_relations = options.resolveRelations.join(',');
   }
 
   if (options.version) {
-    params.version = options.version
+    params.version = options.version;
+  }
+
+  if (options.fromRelease) {
+    params.from_release = options.fromRelease;
   }
 
   if (language.length > 0) {
-    params.language = language
+    params.language = language;
   }
 
-  return params
-}
+  return params;
+};
 
-module.exports = getStoryParams
+module.exports = getStoryParams;

--- a/tests/get-story-params.test.js
+++ b/tests/get-story-params.test.js
@@ -46,4 +46,16 @@ describe('getStoryParams() function', () => {
       resolve_relations: 'page.author,page.categories'
     })
   })
+
+  test('with a language and a version and a from_release options', () => {
+    const options = {
+      version: 'draft',
+      fromRelease: '100'
+    }
+    expect(getStoryParams('en', options)).toEqual({
+      language: 'en',
+      version: 'draft',
+      from_release: '100'
+    })
+  })
 })


### PR DESCRIPTION
This includes the addition of the from_release parameter to the plugin options. This allows for loading stories that are tied up in a specific release that has not been merged yet. This allows for viewing and testing content without having to merge Releases into the current working space or publishing the changes to the Production environment. This should help solve the issue discussed here https://github.com/storyblok/gatsby-source-storyblok/issues/17