### PR TITLE
Fix windows cache path issue

### DIFF
--- a/lib/gatsby-node.js
+++ b/lib/gatsby-node.js
@@ -115,7 +115,7 @@ exports.onCreateNode = async (
       imagePaths.forEach(async (imagePath) => {
         let fileNodeID;
 
-        const mediaDataCacheKey = `sb-${imagePath}`;
+        const mediaDataCacheKey = `sb-${imagePath}`.replace(':','');
         const cacheMediaData = await getCache(mediaDataCacheKey);
         const isCached = cacheMediaData && node.cv === cacheMediaData.updatedAt;
 


### PR DESCRIPTION
Fixes issue where (on windows) the character ":" is not allowed in a folder path.