### PR TITLE
chore/dependencies

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@storyblok/react": "^1.0.5",
+    "gatsby-source-filesystem": "^4.0.0",
     "json-stringify-safe": "^5.0.1",
     "storyblok-js-client": "^4.5.2"
   },
@@ -40,6 +41,9 @@
     "react": "^17.0.1",
     "start-server-and-test": "^1.14.0",
     "vite": "^2.9.9"
+  },
+  "peerDependencies": {
+    "gatsby": "^3.0.0 || ^4.0.0"
   },
   "babel": {
     "presets": [


### PR DESCRIPTION
Hey team. I've added `gatsby-source-filesystem` to the `dependancies` — I think this makes the most sense since a user won't need to add this plugin to their site's `gatsby-config` but without this installed the Storyblok plugin errors.

I've also added Gatsby in `peerDependancies` — I think the Storyblok plugin will now only work with Gatsby 3 and 4 because of how `gatsby-plugin-image` works but do let me know your thoughts on this one.

Thanks

Cheerio

Paul