### PR TITLE
Optionally disable pagination when getAll is called

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,7 @@ export const query = graphql`
 * `resolveRelations`: Resolve relationships to other Stories (in the first level of nesting) of a multi-option or single-option field-type. Provide the field key(s) as array to resolve specific fields. Example: ['article.related_articles', 'article.author'].
 * `includeLinks`: If 'true' you can query links by allStoryblokLinkEntry. The links query lets you create a dynamic navigation tree as it includes also content folders.
 * `languages`: An array of strings that will be used in languages request instead of languages in space settings. Use it to only load the languages that you want to.
+* `disablePagination`: If 'true' the data will be fetched with single api request
 
 #### How to query all Content Entries
 

--- a/lib/gatsby-node.js
+++ b/lib/gatsby-node.js
@@ -66,11 +66,8 @@ exports.sourceNodes = async function ({ actions }, options) {
 
   const datasources = await Sync.getAll('datasources', {
     node: 'StoryblokDatasource',
-    params: {
-      params: {
-        disablePagination: options.disablePagination
-      }
-    }
+    params: getStoryParams('', options)
+    
   });
 
   for (const datasource of datasources) {
@@ -80,9 +77,7 @@ exports.sourceNodes = async function ({ actions }, options) {
       node: 'StoryblokDatasourceEntry',
       params: {
         datasource: datasourceSlug,
-        params: {
-          disablePagination: options.disablePagination
-        }
+        ...getStoryParams('', options)
       },
       process: (item) => {
         item.data_source_dimension = null;
@@ -98,9 +93,7 @@ exports.sourceNodes = async function ({ actions }, options) {
         params: {
           datasource: datasourceSlug,
           dimension: dimension.entry_value,
-          params: {
-            disablePagination: options.disablePagination
-          }
+          ...getStoryParams('', options)
         },
         process: (item) => {
           item.data_source_dimension = dimension.entry_value;

--- a/lib/gatsby-node.js
+++ b/lib/gatsby-node.js
@@ -66,6 +66,11 @@ exports.sourceNodes = async function ({ actions }, options) {
 
   const datasources = await Sync.getAll('datasources', {
     node: 'StoryblokDatasource',
+    params: {
+      params: {
+        disablePagination: options.disablePagination
+      }
+    }
   });
 
   for (const datasource of datasources) {
@@ -75,6 +80,9 @@ exports.sourceNodes = async function ({ actions }, options) {
       node: 'StoryblokDatasourceEntry',
       params: {
         datasource: datasourceSlug,
+        params: {
+          disablePagination: options.disablePagination
+        }
       },
       process: (item) => {
         item.data_source_dimension = null;
@@ -90,6 +98,9 @@ exports.sourceNodes = async function ({ actions }, options) {
         params: {
           datasource: datasourceSlug,
           dimension: dimension.entry_value,
+          params: {
+            disablePagination: options.disablePagination
+          }
         },
         process: (item) => {
           item.data_source_dimension = dimension.entry_value;

--- a/lib/gatsby-node.js
+++ b/lib/gatsby-node.js
@@ -66,8 +66,7 @@ exports.sourceNodes = async function ({ actions }, options) {
 
   const datasources = await Sync.getAll('datasources', {
     node: 'StoryblokDatasource',
-    params: getStoryParams('', options)
-    
+    params: getStoryParams('', options),
   });
 
   for (const datasource of datasources) {
@@ -77,7 +76,7 @@ exports.sourceNodes = async function ({ actions }, options) {
       node: 'StoryblokDatasourceEntry',
       params: {
         datasource: datasourceSlug,
-        ...getStoryParams('', options)
+        ...getStoryParams('', options),
       },
       process: (item) => {
         item.data_source_dimension = null;
@@ -93,7 +92,7 @@ exports.sourceNodes = async function ({ actions }, options) {
         params: {
           datasource: datasourceSlug,
           dimension: dimension.entry_value,
-          ...getStoryParams('', options)
+          ...getStoryParams('', options),
         },
         process: (item) => {
           item.data_source_dimension = dimension.entry_value;

--- a/lib/package.json
+++ b/lib/package.json
@@ -25,7 +25,7 @@
     "@storyblok/react": "^1.0.5",
     "gatsby-source-filesystem": "^4.0.0",
     "json-stringify-safe": "^5.0.1",
-    "storyblok-js-client": "^4.5.2"
+    "storyblok-js-client": "^4.5.6"
   },
   "devDependencies": {
     "@babel/core": "^7.18.0",

--- a/lib/src/getStoryParams.js
+++ b/lib/src/getStoryParams.js
@@ -5,6 +5,7 @@
  * @param  {Array<String>} options.resolveRelations? resolve_relations field
  * @param  {String}        options.resolveLinks? can be story or url
  * @param  {String}        options.version? can be draft or released
+ * @param  {Boolean}       options.disablePagination? disable pagination when getAll is called
  */
 const getStoryParams = function(language = '', options = {}) {
   let params = {}
@@ -23,6 +24,10 @@ const getStoryParams = function(language = '', options = {}) {
 
   if (language.length > 0) {
     params.language = language
+  }
+
+  if (options.disablePagination) {
+    params.disablePagination = options.disablePagination
   }
 
   return params

--- a/lib/src/sync.js
+++ b/lib/src/sync.js
@@ -78,27 +78,15 @@ module.exports = {
   },
 
   async getAll(type, options) {
-    let page = 1;
-    let res = await this.getPage(type, page, options);
-    let all =
-      res.data[type].constructor === Object ? Object.values(res.data[type]) : res.data[type];
-    let lastPage = Math.ceil(res.total / 25);
-
-    while (page < lastPage) {
-      page++;
-      res = await this.getPage(type, page, options);
-      res.data[type].forEach((item) => {
-        all.push(item);
-      });
-    }
+    const all = await this.$client.getAll(`cdn/${type}`, options.params)
 
     all.forEach((item) => {
       if (options.process) {
-        options.process(item);
+        options.process(item)
       }
-      this.createNode(options.node, item);
-    });
+      this.createNode(options.node, item)
+    })
 
-    return all;
+    return all
   },
 };

--- a/lib/src/sync.js
+++ b/lib/src/sync.js
@@ -78,15 +78,34 @@ module.exports = {
   },
 
   async getAll(type, options) {
-    const all = await this.$client.getAll(`cdn/${type}`, options.params)
+    let all = []
+    
+    if(options.disablePagination){
+      all = await this.$client.getAll(`cdn/${type}`, options.params)
+    }
+    else {
+      let page = 1;
+      let res = await this.getPage(type, page, options);
+      all =
+        res.data[type].constructor === Object ? Object.values(res.data[type]) : res.data[type];
+      let lastPage = Math.ceil(res.total / 25);
+
+      while (page < lastPage) {
+        page++;
+        res = await this.getPage(type, page, options);
+        res.data[type].forEach((item) => {
+          all.push(item);
+        });
+      }
+    }
 
     all.forEach((item) => {
       if (options.process) {
-        options.process(item)
+        options.process(item);
       }
-      this.createNode(options.node, item)
-    })
+      this.createNode(options.node, item);
+    });
 
-    return all
+    return all;
   },
 };

--- a/lib/src/sync.js
+++ b/lib/src/sync.js
@@ -81,7 +81,8 @@ module.exports = {
     let all = []
     
     if(options.disablePagination){
-      all = await this.$client.getAll(`cdn/${type}`, options.params)
+      const { disablePagination, ...restOptions } = options.params;
+      all = await this.$client.getAll(`cdn/${type}`, restOptions)
     }
     else {
       let page = 1;

--- a/lib/src/sync.js
+++ b/lib/src/sync.js
@@ -80,7 +80,7 @@ module.exports = {
   async getAll(type, options) {
     let all = []
     
-    if(options.disablePagination){
+    if(options.params.disablePagination){
       const { disablePagination, ...restOptions } = options.params;
       all = await this.$client.getAll(`cdn/${type}`, restOptions)
     }


### PR DESCRIPTION
Added optional option parameter `disablePagination`. 
When is set to `true` the data is fetched with single request instead of using paginated requests of 25 items per page. 
When the parameter is not set or it is `false`, the functionality is not changed.
This speeds up the `source node and transform node` step when having large amount of pages.