### PR TITLE
chore: add keywords to package.json

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -86,5 +86,10 @@
   "homepage": "https://github.com/storyblok/gatsby-source-storyblok",
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "gatsby-source-storyblok"
+  ]
 }


### PR DESCRIPTION
Hey team. I've added some keywords to `lib/package.json` so that the plugin will be automatically picked up and displayed on [https://www.gatsbyjs.com/plugins#cms](https://www.gatsbyjs.com/plugins#cms)

There's more information in our docs about plugin best practices: [https://www.gatsbyjs.com/docs/how-to/plugins-and-themes/submit-to-plugin-library/#keywords](https://www.gatsbyjs.com/docs/how-to/plugins-and-themes/submit-to-plugin-library/#keywords)

Ty team! 