### PR TITLE
Fix/invalid char image windows

### DIFF
--- a/lib/gatsby-node.js
+++ b/lib/gatsby-node.js
@@ -115,7 +115,7 @@ exports.onCreateNode = async (
       imagePaths.forEach(async (imagePath) => {
         let fileNodeID;
 
-        const mediaDataCacheKey = `sb-${imagePath}`;
+        const mediaDataCacheKey = `sb-${imagePath.replace(/[\/|\\|https:]/g, '')}`;
         const cacheMediaData = await getCache(mediaDataCacheKey);
         const isCached = cacheMediaData && node.cv === cacheMediaData.updatedAt;
 

--- a/playground/src/pages/image.tsx
+++ b/playground/src/pages/image.tsx
@@ -1,0 +1,39 @@
+import * as React from "react"
+import { graphql } from "gatsby"
+import { GatsbyImage, getImage } from "gatsby-plugin-image"
+
+function BlogPost({ data }) {
+  const image = getImage(data.file) as any
+  return (
+    <section>
+      <GatsbyImage image={image} alt="test" />
+    </section>
+  )
+}
+
+export default BlogPost
+
+export const pageQuery = graphql`
+  query {
+    storyblokEntry(full_slug: { eq: "gatsby/" }) {
+      content
+      name
+      full_slug
+      uuid
+      id
+      internalId
+    }
+    file(name: {eq: "image-1"}) {
+      name
+      absolutePath
+      publicURL
+      childImageSharp {
+         gatsbyImageData(
+          width: 200
+          placeholder: BLURRED
+          formats: [AUTO, WEBP, AVIF]
+        )
+      }
+    }
+  }
+`


### PR DESCRIPTION
Fix for this issue: [Error: Path contains invalid characters #66](https://github.com/storyblok/gatsby-source-storyblok/issues/66)

- [x] remove `https:` and `//` when creating image folders/files