### PR TITLE
feat(SDK-36): live loading feature release

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Use `<StoryblokStory />` to get the new story every time is triggered a `change`
 
 #### 2. Link your components to Storyblok Visual Editor
 
-`<StoryblokStory />` keeps the state for thet story behind the scenes and uses `StoryblokComponent` to render the route components dynamically, using the list of components loaded during the initialization inside the storyblokInit function. You can use the `StoryblokComponent` inside the components to redner the nested components dynamically.
+`<StoryblokStory />` keeps the state for the story behind the scenes and uses `StoryblokComponent` to render the route components dynamically, using the list of components loaded during the initialization inside the storyblokInit function. You can use the `StoryblokComponent` inside the components to redner the nested components dynamically.
 
 For every component you've defined in your Storyblok space, call the `storyblokEditable` function with the blok content:
 
@@ -248,7 +248,7 @@ storyblokInit({});
 
 #### Storyblok Bridge
 
-If you don't use `useStoryblokBridge`, you still have access to the raw `window.StoryblokBridge`:
+If you don't use `registerStoryblokBridge`, you still have access to the raw `window.StoryblokBridge`:
 
 ```js
 const sbBridge = new window.StoryblokBridge(options);
@@ -377,16 +377,13 @@ For more info regarding `createPages` see the Gatsby docs: [docs/reference/confi
 2a. You need to create a [template](https://www.gatsbyjs.org/docs/programmatically-create-pages-from-data/#specifying-a-template) file to get the data from GraphQL
 
 ```js
-import { useStoryblokState } from "gatsby-source-storyblok"
-import Layout from "../components/layout"
+import { StoryblokStory } from "gatsby-source-storyblok";
+import Layout from "../components/layout";
 
 export default function StoryblokEntry ({ data }) {
-  const story = data.storyblokEntry
-  story = useStoryblokState(story)
-
   return (
     <Layout>
-      <div>{story.name}</div>
+      <StoryblokStory story={data.storyblokEntry} />
     </Layout>
   )
 }
@@ -458,16 +455,14 @@ For more info regarding The File System Routes API see the Gatsby docs: [docs/re
 3b. Gatsby will use ths page template for each `storyblokEntry`
 
 ```js
-import { useStoryblokState } from "gatsby-source-storyblok"
-import Layout from "../components/layout"
+import { StoryblokStory } from "gatsby-source-storyblok";
+
+import Layout from "../components/layout";
 
 export default function StoryblokEntry ({ data }) {
-  const story = data.storyblokEntry
-  story = useStoryblokState(story)
-
   return (
     <Layout>
-      <div>{story.name}</div>
+      <StoryblokStory story={data.storyblokEntry} />
     </Layout>
   )
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,4 @@
 export {
-  // useStoryblokBridge,
   storyblokInit,
   apiPlugin,
   StoryblokComponent,
@@ -10,8 +9,5 @@ export {
 } from "@storyblok/react/rsc";
 
 export { default as StoryblokStory } from "./story";
-
-// Reexport all types so users can have access to them
-// Maybe, need to review the types to make sure they are correct
 export * from "./types";
 export * from "./src/common";

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -9,6 +9,8 @@ export {
   renderRichText,
 } from "@storyblok/react/rsc";
 
+export { default as StoryblokStory } from "./story";
+
 // Reexport all types so users can have access to them
 // Maybe, need to review the types to make sure they are correct
 export * from "./types";

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,7 +1,5 @@
-import { useEffect, useState } from "react";
-import { useStoryblokBridge as useSbBridge } from "@storyblok/react/rsc";
 export {
-  useStoryblokBridge,
+  // useStoryblokBridge,
   storyblokInit,
   apiPlugin,
   StoryblokComponent,
@@ -10,12 +8,16 @@ export {
   getStoryblokApi,
   renderRichText,
 } from "@storyblok/react/rsc";
-export { default as StoryblokStory } from "@storyblok/react/story";
-
-import type {
-  SbGatsbyStory,
-  StoryblokBridgeConfigV2
-} from './types'
 
 // Reexport all types so users can have access to them
+// Maybe, need to review the types to make sure they are correct
 export * from "./types";
+export * from "./src/common";
+
+// 1. ✅Copy paste useStoryblokBridge and useStoryblokState from JS SDK & React SDK to Gatsby SDK
+// 2. ✅Implement the refreshDevContent function and add it to the useStoryblokBridge (like in the example)
+// 3. Copy paste lib/story.jsx from React SDK to Gatsby SDK (possibly, common/client.ts too) -> Maybe, Gatsby SDK doesn’t need to follow this structure if it was for Next.js specific reason?
+// 4. ✅ Delete export of StoryblokStory and remove useStoryblokBridge export
+// 5. Make the build changes to build StoryblokStory
+   // 5.1. Vite config: add extra entry point, terser config + devDependency, banner config
+   // 5.2. Update lib/package.json to add new entry point

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -13,11 +13,3 @@ export {
 // Maybe, need to review the types to make sure they are correct
 export * from "./types";
 export * from "./src/common";
-
-// 1. ✅Copy paste useStoryblokBridge and useStoryblokState from JS SDK & React SDK to Gatsby SDK
-// 2. ✅Implement the refreshDevContent function and add it to the useStoryblokBridge (like in the example)
-// 3. Copy paste lib/story.jsx from React SDK to Gatsby SDK (possibly, common/client.ts too) -> Maybe, Gatsby SDK doesn’t need to follow this structure if it was for Next.js specific reason?
-// 4. ✅ Delete export of StoryblokStory and remove useStoryblokBridge export
-// 5. Make the build changes to build StoryblokStory
-   // 5.1. Vite config: add extra entry point, terser config + devDependency, banner config
-   // 5.2. Update lib/package.json to add new entry point

--- a/lib/package.json
+++ b/lib/package.json
@@ -10,18 +10,6 @@
     "dist",
     "src"
   ],
-  "exports": {
-    ".": {
-      "types": "./dist/types/index.d.ts",
-      "import": "./dist/gatsby-source-storyblok.mjs",
-      "require": "./dist/gatsby-source-storyblok.js"
-    },
-    "./story": {
-      "types": "./dist/types/story.d.ts",
-      "import": "./dist/gatsby-source-storyblok2.mjs",
-      "require": "./dist/gatsby-source-storyblok2.js"
-    }
-  },
   "scripts": {
     "dev": "vite build --watch",
     "build": "vite build && tsc --project tsconfig.json",
@@ -53,9 +41,9 @@
     "jest": "^29.6.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "rollup-plugin-preserve-directives": "^0.2.0",
     "start-server-and-test": "^2.0.0",
     "typescript": "^5.1.3",
-    "terser": "^5.18.2",
     "vite": "^4.4.4"
   },
   "peerDependencies": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -10,6 +10,18 @@
     "dist",
     "src"
   ],
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/gatsby-source-storyblok.mjs",
+      "require": "./dist/gatsby-source-storyblok.js"
+    },
+    "./story": {
+      "types": "./dist/types/story.d.ts",
+      "import": "./dist/gatsby-source-storyblok2.mjs",
+      "require": "./dist/gatsby-source-storyblok2.js"
+    }
+  },
   "scripts": {
     "dev": "vite build --watch",
     "build": "vite build && tsc --project tsconfig.json",
@@ -43,6 +55,7 @@
     "react-dom": "^18.2.0",
     "start-server-and-test": "^2.0.0",
     "typescript": "^5.1.3",
+    "terser": "^5.18.2",
     "vite": "^4.4.4"
   },
   "peerDependencies": {

--- a/lib/src/common.ts
+++ b/lib/src/common.ts
@@ -1,0 +1,70 @@
+import { useEffect, useState } from "react";
+
+import type {
+  SbGatsbyStory,
+  StoryblokBridgeConfigV2
+} from '../types'
+
+
+export const useStoryblokBridge = (
+  id: Number,
+  cb: (newStory) => void,
+  options: StoryblokBridgeConfigV2 = {},
+) => {
+  const isServer = typeof window === "undefined";
+  const isBridgeLoaded =
+    !isServer && typeof window.storyblokRegisterEvent !== "undefined";
+  const storyId = new URL(window.location?.href).searchParams.get(
+    "_storyblok"
+  );
+  const inStory = +storyId === id;
+
+  if (!isBridgeLoaded || !inStory) {
+    return;
+  }
+
+  if (!id) {
+    console.warn("Story ID is not defined. Please provide a valid ID.");
+    return;
+  }
+
+  const refreshDevContent = () => {
+    return fetch('__refresh', { method: 'post' });
+  }
+
+  window.storyblokRegisterEvent(() => {
+    const sbBridge = new window.StoryblokBridge(options);
+    sbBridge.on(["input", "published", "change"], async (event) => {
+      if (event.action === "input" && event.story.id === id) {
+        cb(event.story);
+      } else if (
+        (event.action === "change" || event.action === "published") &&
+        (event.storyId as number) === id
+      ) {
+        await refreshDevContent();
+        setTimeout(() => {
+          window.location.reload();
+        }, 50)
+      }
+    });
+  });
+};
+
+export function useStoryblokState(
+  originalStory: SbGatsbyStory,
+  bridgeOptions: StoryblokBridgeConfigV2 = {}
+) {
+  if (typeof originalStory.content === 'string')
+    originalStory.content = JSON.parse(originalStory.content);
+
+  let [story, setStory] = useState(originalStory);
+  useEffect(() => {
+    useStoryblokBridge(
+      story.internalId,
+      (newStory) => setStory(newStory as SbGatsbyStory),
+      bridgeOptions
+    );
+  }, []);
+
+  return story;
+}

--- a/lib/src/common.ts
+++ b/lib/src/common.ts
@@ -41,6 +41,7 @@ export const useStoryblokBridge = (
         (event.action === "change" || event.action === "published") &&
         (event.storyId as number) === id
       ) {
+        // @workaround: give extra time to Gatsby to refresh content before reloading
         await refreshDevContent();
         setTimeout(() => {
           window.location.reload();

--- a/lib/src/common.ts
+++ b/lib/src/common.ts
@@ -69,3 +69,5 @@ export function useStoryblokState(
 
   return story;
 }
+
+export { useStoryblokBridge as registerStoryblokBridge };

--- a/lib/story.tsx
+++ b/lib/story.tsx
@@ -3,30 +3,19 @@
 import React, { forwardRef } from "react";
 import { StoryblokComponent } from "@storyblok/react";
 import { useStoryblokState } from "./src/common";
-import { ISbStoryData } from "./types";
+import { ISbGatsbyDataEntry } from "./types";
 
 interface StoryblokStoryProps {
-  story: ISbStoryData;
+  data: ISbGatsbyDataEntry;
   [key: string]: unknown;
 }
 
-// 🚨 WIP copied from REact SDK story.tsx
 const StoryblokStory = forwardRef<HTMLElement, StoryblokStoryProps>(
-  ({ story, ...restProps }, ref) => {
-    if (typeof story.content === "string") story.content = JSON.parse(story.content);
-    story = useStoryblokState(story as any);
+  ({ data, ...restProps }, ref) => {
+    let story = data.storyblokEntry;
+    story = useStoryblokState(story);
     return <StoryblokComponent ref={ref} blok={story.content} {...restProps} />;
   }
 );
-
-// 🚨 WIP modifying in Gatsby way
-// const StoryblokStory = forwardRef<HTMLElement, StoryblokStoryProps>(
-//   ({ data, ...restProps }, ref) => {
-//     let story = data.storyblokEntry as any;
-//     if (typeof story.content === "string") story.content = JSON.parse(story.content);
-//     story = useStoryblokState(story as any);
-//     return <StoryblokComponent ref={ref} blok={story.content} {...restProps} />;
-//   }
-// );
 
 export default StoryblokStory;

--- a/lib/story.tsx
+++ b/lib/story.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import React, { forwardRef } from "react";
+import { StoryblokComponent } from "@storyblok/react";
+import { useStoryblokState } from "./src/common";
+import { ISbStoryData } from "./types";
+
+interface StoryblokStoryProps {
+  story: ISbStoryData;
+  [key: string]: unknown;
+}
+
+// 🚨 WIP copied from REact SDK story.tsx
+const StoryblokStory = forwardRef<HTMLElement, StoryblokStoryProps>(
+  ({ story, ...restProps }, ref) => {
+    if (typeof story.content === "string") story.content = JSON.parse(story.content);
+    story = useStoryblokState(story as any);
+    return <StoryblokComponent ref={ref} blok={story.content} {...restProps} />;
+  }
+);
+
+// 🚨 WIP modifying in Gatsby way
+// const StoryblokStory = forwardRef<HTMLElement, StoryblokStoryProps>(
+//   ({ data, ...restProps }, ref) => {
+//     let story = data.storyblokEntry as any;
+//     if (typeof story.content === "string") story.content = JSON.parse(story.content);
+//     story = useStoryblokState(story as any);
+//     return <StoryblokComponent ref={ref} blok={story.content} {...restProps} />;
+//   }
+// );
+
+export default StoryblokStory;

--- a/lib/story.tsx
+++ b/lib/story.tsx
@@ -3,16 +3,15 @@
 import React, { forwardRef } from "react";
 import { StoryblokComponent } from "@storyblok/react";
 import { useStoryblokState } from "./src/common";
-import { ISbGatsbyDataEntry } from "./types";
+import { SbGatsbyStory } from "./types";
 
 interface StoryblokStoryProps {
-  data: ISbGatsbyDataEntry;
+  story: SbGatsbyStory;
   [key: string]: unknown;
 }
 
 const StoryblokStory = forwardRef<HTMLElement, StoryblokStoryProps>(
-  ({ data, ...restProps }, ref) => {
-    let story = data.storyblokEntry;
+  ({ story, ...restProps }, ref) => {
     story = useStoryblokState(story);
     return <StoryblokComponent ref={ref} blok={story.content} {...restProps} />;
   }

--- a/lib/story.tsx
+++ b/lib/story.tsx
@@ -3,10 +3,11 @@
 import React, { forwardRef } from "react";
 import { StoryblokComponent } from "@storyblok/react";
 import { useStoryblokState } from "./src/common";
-import { SbGatsbyStory } from "./types";
+import { SbGatsbyStory, StoryblokBridgeConfigV2 } from "./types";
 
 interface StoryblokStoryProps {
   story: SbGatsbyStory;
+  bridgeOptions: StoryblokBridgeConfigV2;
   [key: string]: unknown;
 }
 

--- a/lib/tsconfig.json
+++ b/lib/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "jsx": "react",
     "isolatedModules": true,
     "target": "ESNext",
     "strict": false,
@@ -17,6 +18,7 @@
   "display": "Recommended",
   "include": [
     "./index.ts",
+    "./story.tsx",
     "./types.ts"
   ],
   "exclude": [

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -10,10 +10,6 @@ export interface SbGatsbyStory
   internalId: number;
 }
 
-export interface ISbGatsbyDataEntry {
-  storyblokEntry: SbGatsbyStory;
-}
-
 export type {
   ISbConfig,
   ISbCache,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,9 +1,18 @@
-import type { ISbStoryData, StoryblokComponentType } from "@storyblok/react/rsc";
+import type {
+  ISbStoryData,
+  StoryblokComponentType,
+} from "@storyblok/react/rsc";
 
-export interface SbGatsbyStory extends ISbStoryData<StoryblokComponentType<string> & { [index: string]: any; }> {
-  internalId: number
+export interface SbGatsbyStory
+  extends ISbStoryData<
+    StoryblokComponentType<string> & { [index: string]: any }
+  > {
+  internalId: number;
 }
 
+export interface ISbGatsbyDataEntry {
+  storyblokEntry: SbGatsbyStory;
+}
 
 export type {
   ISbConfig,

--- a/lib/vite.config.ts
+++ b/lib/vite.config.ts
@@ -7,15 +7,28 @@ export default defineConfig(() => {
   return {
     build: {
       lib: {
-        entry: path.resolve(__dirname, "index.ts"),
+        entry: [
+          path.resolve(__dirname, "index.ts"),
+          path.resolve(__dirname, "story.tsx"),
+        ],
         name: "storyblokGatsby",
         fileName: (format) =>
           format === "es" ? `${libName}.mjs` : `${libName}.js`,
+      },
+      minify: "terser",
+      terserOptions: {
+        compress: {
+          directives: false,
+        },
       },
       rollupOptions: {
         external: ["react"],
         output: {
           globals: { react: "React" },
+          banner: (chunk) =>
+            ["story"].includes(chunk.name)
+              ? '"use client";'
+              : "",
         },
       },
     },

--- a/lib/vite.config.ts
+++ b/lib/vite.config.ts
@@ -1,10 +1,12 @@
 import { defineConfig } from "vite";
 import path from "path";
+import preserveDirectives from "rollup-plugin-preserve-directives";
 
 const libName = "gatsby-source-storyblok";
 
 export default defineConfig(() => {
   return {
+    plugins: [preserveDirectives()],
     build: {
       lib: {
         entry: [
@@ -15,20 +17,11 @@ export default defineConfig(() => {
         fileName: (format) =>
           format === "es" ? `${libName}.mjs` : `${libName}.js`,
       },
-      minify: "terser",
-      terserOptions: {
-        compress: {
-          directives: false,
-        },
-      },
       rollupOptions: {
         external: ["react"],
         output: {
+          preserveModules: true,
           globals: { react: "React" },
-          banner: (chunk) =>
-            ["story"].includes(chunk.name)
-              ? '"use client";'
-              : "",
         },
       },
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,6 @@
         "react-dom": "^18.2.0",
         "rollup-plugin-preserve-directives": "^0.2.0",
         "start-server-and-test": "^2.0.0",
-        "terser": "^5.18.2",
         "typescript": "^5.1.3",
         "vite": "^4.4.4"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "start-server-and-test": "^2.0.0",
+        "terser": "^5.18.2",
         "typescript": "^5.1.3",
         "vite": "^4.4.4"
       },
@@ -19796,9 +19797,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.17.7",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.17.7.tgz",
-      "integrity": "sha512-/bi0Zm2C6VAexlGgLlVxA0P2lru/sdLyfCVaRMfKVo9nWxbmz7f/sD8VPybPeSUJaJcwmCJis9pBIhcVcG1QcQ==",
+      "version": "5.19.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.2.tgz",
+      "integrity": "sha512-qC5+dmecKJA4cpYxRa5aVkKehYsQKc+AHeKl0Oe62aYjBL8ZA33tTljktDHJSaxxMnbI5ZYw+o/S2DxxLu8OfA==",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",
@@ -21241,31 +21242,27 @@
     },
     "playground": {
       "version": "1.0.0",
-      "dependencies": {
-        "gatsby": "^5.7.0",
-        "gatsby-source-storyblok": "^1.0.0",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
-      },
       "devDependencies": {
         "@types/node": "^20.4.2",
         "@types/react": "^18.2.15",
         "@types/react-dom": "^18.2.7",
+        "gatsby": "^5.7.0",
+        "gatsby-source-storyblok": "^1.0.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
         "typescript": "^5.1.6"
       }
     },
     "playground-test": {
       "version": "1.0.0",
-      "dependencies": {
-        "gatsby": "^5.7.0",
-        "gatsby-source-storyblok": "^1.0.0",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
-      },
       "devDependencies": {
         "@types/node": "^20.4.2",
         "@types/react": "^18.2.15",
         "@types/react-dom": "^18.2.7",
+        "gatsby": "^5.7.0",
+        "gatsby-source-storyblok": "^1.0.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
         "typescript": "^4.9.5"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "jest": "^29.6.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "rollup-plugin-preserve-directives": "^0.2.0",
         "start-server-and-test": "^2.0.0",
         "terser": "^5.18.2",
         "typescript": "^5.1.3",
@@ -15370,6 +15371,18 @@
         "es5-ext": "~0.10.2"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.2",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.2.tgz",
+      "integrity": "sha512-lNZdu7pewtq/ZvWUp9Wpf/x7WzMTsR26TWV03BRZrXFsv+BI6dy8RAiKgm1uM/kyR0rCfUcqvOlXKG66KhIGug==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -18605,6 +18618,18 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup-plugin-preserve-directives": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-preserve-directives/-/rollup-plugin-preserve-directives-0.2.0.tgz",
+      "integrity": "sha512-KUwbBaFvD1zFIDNnOkR+u64sSod3m0l6q46/SzTOa4GTQ6hp6w0FRr2u7x99YkY9qhlna5panmTmuLWeJ/2KWw==",
+      "dev": true,
+      "dependencies": {
+        "magic-string": "^0.30.0"
+      },
+      "peerDependencies": {
+        "rollup": "2.x || 3.x"
       }
     },
     "node_modules/run-async": {

--- a/playground-test/package.json
+++ b/playground-test/package.json
@@ -15,13 +15,11 @@
     "clean": "gatsby clean",
     "typecheck": "tsc --noEmit"
   },
-  "dependencies": {
+  "devDependencies": {
     "gatsby": "^5.7.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "gatsby-source-storyblok": "^1.0.0"
-  },
-  "devDependencies": {
+    "gatsby-source-storyblok": "^1.0.0",
     "@types/node": "^20.4.2",
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",

--- a/playground/package.json
+++ b/playground/package.json
@@ -15,13 +15,11 @@
     "clean": "gatsby clean",
     "typecheck": "tsc --noEmit"
   },
-  "dependencies": {
+  "devDependencies": {
     "gatsby": "^5.7.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "gatsby-source-storyblok": "^1.0.0"
-  },
-  "devDependencies": {
+    "gatsby-source-storyblok": "^1.0.0",
     "@types/node": "^20.4.2",
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",

--- a/playground/src/components/Page.tsx
+++ b/playground/src/components/Page.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { storyblokEditable, StoryblokComponent } from "gatsby-source-storyblok";
 
 const Page = ({ blok }) => {
-  console.log(blok);
   return (
     <main {...storyblokEditable(blok)}>
       {blok.body.map((nestedBlok) => (

--- a/playground/src/components/Page.tsx
+++ b/playground/src/components/Page.tsx
@@ -1,12 +1,15 @@
 import React from "react";
 import { storyblokEditable, StoryblokComponent } from "gatsby-source-storyblok";
 
-const Page = ({ blok }) => (
-  <main {...storyblokEditable(blok)}>
-    {blok.body.map((nestedBlok) => (
-      <StoryblokComponent blok={nestedBlok} key={nestedBlok._uid} />
-    ))}
-  </main>
-);
+const Page = ({ blok }) => {
+  console.log(blok);
+  return (
+    <main {...storyblokEditable(blok)}>
+      {blok.body.map((nestedBlok) => (
+        <StoryblokComponent blok={nestedBlok} key={nestedBlok._uid} />
+      ))}
+    </main>
+  )
+};
 
 export default Page;

--- a/playground/src/components/layout.jsx
+++ b/playground/src/components/layout.jsx
@@ -5,7 +5,7 @@
  * See: https://www.gatsbyjs.com/docs/use-static-query/
  */
 "use client";
-import React, { useEffect } from "react"
+import React from "react"
 import PropTypes from "prop-types"
 import { storyblokInit, apiPlugin } from "gatsby-source-storyblok"
 import Teaser from './Teaser'

--- a/playground/src/components/layout.jsx
+++ b/playground/src/components/layout.jsx
@@ -28,6 +28,7 @@ storyblokInit({
 });
 
 const Layout = ({ children }) => {
+  console.log(children)
   return (
     <div>
       <main>{children}</main>

--- a/playground/src/components/layout.jsx
+++ b/playground/src/components/layout.jsx
@@ -28,7 +28,6 @@ storyblokInit({
 });
 
 const Layout = ({ children }) => {
-  console.log(children)
   return (
     <div>
       <main>{children}</main>

--- a/playground/src/gatsby-types.d.ts
+++ b/playground/src/gatsby-types.d.ts
@@ -355,8 +355,6 @@ type File = Node & {
   readonly birthtime: Maybe<Scalars['Date']>;
   /** @deprecated Use `birthTime` instead */
   readonly birthtimeMs: Maybe<Scalars['Float']>;
-  readonly blksize: Maybe<Scalars['Int']>;
-  readonly blocks: Maybe<Scalars['Int']>;
   readonly changeTime: Scalars['Date'];
   readonly children: ReadonlyArray<Node>;
   readonly ctime: Scalars['Date'];
@@ -384,7 +382,6 @@ type File = Node & {
   readonly size: Scalars['Int'];
   readonly sourceInstanceName: Scalars['String'];
   readonly uid: Scalars['Int'];
-  readonly url: Maybe<Scalars['String']>;
 };
 
 
@@ -497,8 +494,6 @@ type FileFieldSelector = {
   readonly birthTime: InputMaybe<FieldSelectorEnum>;
   readonly birthtime: InputMaybe<FieldSelectorEnum>;
   readonly birthtimeMs: InputMaybe<FieldSelectorEnum>;
-  readonly blksize: InputMaybe<FieldSelectorEnum>;
-  readonly blocks: InputMaybe<FieldSelectorEnum>;
   readonly changeTime: InputMaybe<FieldSelectorEnum>;
   readonly children: InputMaybe<NodeFieldSelector>;
   readonly ctime: InputMaybe<FieldSelectorEnum>;
@@ -526,7 +521,6 @@ type FileFieldSelector = {
   readonly size: InputMaybe<FieldSelectorEnum>;
   readonly sourceInstanceName: InputMaybe<FieldSelectorEnum>;
   readonly uid: InputMaybe<FieldSelectorEnum>;
-  readonly url: InputMaybe<FieldSelectorEnum>;
 };
 
 type FileFilterInput = {
@@ -538,8 +532,6 @@ type FileFilterInput = {
   readonly birthTime: InputMaybe<DateQueryOperatorInput>;
   readonly birthtime: InputMaybe<DateQueryOperatorInput>;
   readonly birthtimeMs: InputMaybe<FloatQueryOperatorInput>;
-  readonly blksize: InputMaybe<IntQueryOperatorInput>;
-  readonly blocks: InputMaybe<IntQueryOperatorInput>;
   readonly changeTime: InputMaybe<DateQueryOperatorInput>;
   readonly children: InputMaybe<NodeFilterListInput>;
   readonly ctime: InputMaybe<DateQueryOperatorInput>;
@@ -567,7 +559,6 @@ type FileFilterInput = {
   readonly size: InputMaybe<IntQueryOperatorInput>;
   readonly sourceInstanceName: InputMaybe<StringQueryOperatorInput>;
   readonly uid: InputMaybe<IntQueryOperatorInput>;
-  readonly url: InputMaybe<StringQueryOperatorInput>;
 };
 
 type FileGroupConnection = {
@@ -620,8 +611,6 @@ type FileSortInput = {
   readonly birthTime: InputMaybe<SortOrderEnum>;
   readonly birthtime: InputMaybe<SortOrderEnum>;
   readonly birthtimeMs: InputMaybe<SortOrderEnum>;
-  readonly blksize: InputMaybe<SortOrderEnum>;
-  readonly blocks: InputMaybe<SortOrderEnum>;
   readonly changeTime: InputMaybe<SortOrderEnum>;
   readonly children: InputMaybe<NodeSortInput>;
   readonly ctime: InputMaybe<SortOrderEnum>;
@@ -649,7 +638,6 @@ type FileSortInput = {
   readonly size: InputMaybe<SortOrderEnum>;
   readonly sourceInstanceName: InputMaybe<SortOrderEnum>;
   readonly uid: InputMaybe<SortOrderEnum>;
-  readonly url: InputMaybe<SortOrderEnum>;
 };
 
 type FloatQueryOperatorInput = {
@@ -916,8 +904,6 @@ type Query_fileArgs = {
   birthTime: InputMaybe<DateQueryOperatorInput>;
   birthtime: InputMaybe<DateQueryOperatorInput>;
   birthtimeMs: InputMaybe<FloatQueryOperatorInput>;
-  blksize: InputMaybe<IntQueryOperatorInput>;
-  blocks: InputMaybe<IntQueryOperatorInput>;
   changeTime: InputMaybe<DateQueryOperatorInput>;
   children: InputMaybe<NodeFilterListInput>;
   ctime: InputMaybe<DateQueryOperatorInput>;
@@ -945,7 +931,6 @@ type Query_fileArgs = {
   size: InputMaybe<IntQueryOperatorInput>;
   sourceInstanceName: InputMaybe<StringQueryOperatorInput>;
   uid: InputMaybe<IntQueryOperatorInput>;
-  url: InputMaybe<StringQueryOperatorInput>;
 };
 
 

--- a/playground/src/gatsby-types.d.ts
+++ b/playground/src/gatsby-types.d.ts
@@ -355,6 +355,8 @@ type File = Node & {
   readonly birthtime: Maybe<Scalars['Date']>;
   /** @deprecated Use `birthTime` instead */
   readonly birthtimeMs: Maybe<Scalars['Float']>;
+  readonly blksize: Maybe<Scalars['Int']>;
+  readonly blocks: Maybe<Scalars['Int']>;
   readonly changeTime: Scalars['Date'];
   readonly children: ReadonlyArray<Node>;
   readonly ctime: Scalars['Date'];
@@ -382,6 +384,7 @@ type File = Node & {
   readonly size: Scalars['Int'];
   readonly sourceInstanceName: Scalars['String'];
   readonly uid: Scalars['Int'];
+  readonly url: Maybe<Scalars['String']>;
 };
 
 
@@ -494,6 +497,8 @@ type FileFieldSelector = {
   readonly birthTime: InputMaybe<FieldSelectorEnum>;
   readonly birthtime: InputMaybe<FieldSelectorEnum>;
   readonly birthtimeMs: InputMaybe<FieldSelectorEnum>;
+  readonly blksize: InputMaybe<FieldSelectorEnum>;
+  readonly blocks: InputMaybe<FieldSelectorEnum>;
   readonly changeTime: InputMaybe<FieldSelectorEnum>;
   readonly children: InputMaybe<NodeFieldSelector>;
   readonly ctime: InputMaybe<FieldSelectorEnum>;
@@ -521,6 +526,7 @@ type FileFieldSelector = {
   readonly size: InputMaybe<FieldSelectorEnum>;
   readonly sourceInstanceName: InputMaybe<FieldSelectorEnum>;
   readonly uid: InputMaybe<FieldSelectorEnum>;
+  readonly url: InputMaybe<FieldSelectorEnum>;
 };
 
 type FileFilterInput = {
@@ -532,6 +538,8 @@ type FileFilterInput = {
   readonly birthTime: InputMaybe<DateQueryOperatorInput>;
   readonly birthtime: InputMaybe<DateQueryOperatorInput>;
   readonly birthtimeMs: InputMaybe<FloatQueryOperatorInput>;
+  readonly blksize: InputMaybe<IntQueryOperatorInput>;
+  readonly blocks: InputMaybe<IntQueryOperatorInput>;
   readonly changeTime: InputMaybe<DateQueryOperatorInput>;
   readonly children: InputMaybe<NodeFilterListInput>;
   readonly ctime: InputMaybe<DateQueryOperatorInput>;
@@ -559,6 +567,7 @@ type FileFilterInput = {
   readonly size: InputMaybe<IntQueryOperatorInput>;
   readonly sourceInstanceName: InputMaybe<StringQueryOperatorInput>;
   readonly uid: InputMaybe<IntQueryOperatorInput>;
+  readonly url: InputMaybe<StringQueryOperatorInput>;
 };
 
 type FileGroupConnection = {
@@ -611,6 +620,8 @@ type FileSortInput = {
   readonly birthTime: InputMaybe<SortOrderEnum>;
   readonly birthtime: InputMaybe<SortOrderEnum>;
   readonly birthtimeMs: InputMaybe<SortOrderEnum>;
+  readonly blksize: InputMaybe<SortOrderEnum>;
+  readonly blocks: InputMaybe<SortOrderEnum>;
   readonly changeTime: InputMaybe<SortOrderEnum>;
   readonly children: InputMaybe<NodeSortInput>;
   readonly ctime: InputMaybe<SortOrderEnum>;
@@ -638,6 +649,7 @@ type FileSortInput = {
   readonly size: InputMaybe<SortOrderEnum>;
   readonly sourceInstanceName: InputMaybe<SortOrderEnum>;
   readonly uid: InputMaybe<SortOrderEnum>;
+  readonly url: InputMaybe<SortOrderEnum>;
 };
 
 type FloatQueryOperatorInput = {
@@ -904,6 +916,8 @@ type Query_fileArgs = {
   birthTime: InputMaybe<DateQueryOperatorInput>;
   birthtime: InputMaybe<DateQueryOperatorInput>;
   birthtimeMs: InputMaybe<FloatQueryOperatorInput>;
+  blksize: InputMaybe<IntQueryOperatorInput>;
+  blocks: InputMaybe<IntQueryOperatorInput>;
   changeTime: InputMaybe<DateQueryOperatorInput>;
   children: InputMaybe<NodeFilterListInput>;
   ctime: InputMaybe<DateQueryOperatorInput>;
@@ -931,6 +945,7 @@ type Query_fileArgs = {
   size: InputMaybe<IntQueryOperatorInput>;
   sourceInstanceName: InputMaybe<StringQueryOperatorInput>;
   uid: InputMaybe<IntQueryOperatorInput>;
+  url: InputMaybe<StringQueryOperatorInput>;
 };
 
 

--- a/playground/src/pages/index.tsx
+++ b/playground/src/pages/index.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import { graphql } from "gatsby";
 
-//6.1.0 --> feat: now you can refresh & Won't break StoryblokStory approach
 import { StoryblokStory } from "gatsby-source-storyblok";
 
 import Layout from "../components/layout";
@@ -13,18 +12,6 @@ const IndexPage = ({ data }) => {
       <StoryblokStory story={data.storyblokEntry} />
     </Layout>
   );
-
-  // 🚨 Gatsby V4 support code, old approach -> Move later as a new page in page directory
-  // let story = data.storyblokEntry
-  // story = useStoryblokState(story)
-
-  // const components = story.content.body.map(blok => (<StoryblokComponent blok={blok} key={blok._uid} />))
-
-  // return (
-  //   <Layout>
-  //     {components}
-  //   </Layout>
-  // )
 };
 
 export default IndexPage;

--- a/playground/src/pages/index.tsx
+++ b/playground/src/pages/index.tsx
@@ -1,8 +1,6 @@
 import * as React from "react"
 import { graphql } from "gatsby"
 
-//6.0.2
-import { useStoryblokState, StoryblokComponent } from "gatsby-source-storyblok"
 //6.1.0 --> feat: now you can refresh & Won't break StoryblokStory approach
 import StoryblokStory from "gatsby-source-storyblok/story"
 

--- a/playground/src/pages/index.tsx
+++ b/playground/src/pages/index.tsx
@@ -1,18 +1,37 @@
 import * as React from "react"
 import { graphql } from "gatsby"
 
-import { StoryblokStory } from "gatsby-source-storyblok"
+//6.0.2
+import { useStoryblokState, StoryblokComponent } from "gatsby-source-storyblok"
+//6.1.0 --> feat: now you can refresh & Won't break StoryblokStory approach
+import StoryblokStory from "gatsby-source-storyblok/story"
 
 import Layout from "../components/layout"
 
 const IndexPage = ({ data }) => {
+  // 🚨 Gatsby V5 support original playground code
   if (typeof data.storyblokEntry.content === "string") data.storyblokEntry.content = JSON.parse(data.storyblokEntry.content);
+
+  console.log(<StoryblokStory story={data.storyblokEntry.content} blok={data.storyblokEntry.content} />)
 
   return (
     <Layout>
-      <StoryblokStory story={data.storyblokEntry} />
+      <h1>{data.storyblokEntry.name}</h1>
+      <StoryblokStory story={data.storyblokEntry.content} blok={data.storyblokEntry.content} />
     </Layout>
   )
+
+  // 🚨 Gatsby V4 support code, old approach -> Move later as a new page in page directory
+  // let story = data.storyblokEntry
+  // story = useStoryblokState(story)
+
+  // const components = story.content.body.map(blok => (<StoryblokComponent blok={blok} key={blok._uid} />))
+
+  // return (
+  //   <Layout>
+  //     {components}
+  //   </Layout>
+  // )
 }
 
 export default IndexPage

--- a/playground/src/pages/index.tsx
+++ b/playground/src/pages/index.tsx
@@ -1,23 +1,18 @@
-import * as React from "react"
-import { graphql } from "gatsby"
+import * as React from "react";
+import { graphql } from "gatsby";
 
 //6.1.0 --> feat: now you can refresh & Won't break StoryblokStory approach
-import StoryblokStory from "gatsby-source-storyblok/story"
+import { StoryblokStory } from "gatsby-source-storyblok";
 
-import Layout from "../components/layout"
+import Layout from "../components/layout";
 
 const IndexPage = ({ data }) => {
-  // 🚨 Gatsby V5 support original playground code
-  if (typeof data.storyblokEntry.content === "string") data.storyblokEntry.content = JSON.parse(data.storyblokEntry.content);
-
-  console.log(<StoryblokStory story={data.storyblokEntry.content} blok={data.storyblokEntry.content} />)
-
   return (
     <Layout>
       <h1>{data.storyblokEntry.name}</h1>
-      <StoryblokStory story={data.storyblokEntry.content} blok={data.storyblokEntry.content} />
+      <StoryblokStory story={data.storyblokEntry} />
     </Layout>
-  )
+  );
 
   // 🚨 Gatsby V4 support code, old approach -> Move later as a new page in page directory
   // let story = data.storyblokEntry
@@ -30,9 +25,9 @@ const IndexPage = ({ data }) => {
   //     {components}
   //   </Layout>
   // )
-}
+};
 
-export default IndexPage
+export default IndexPage;
 
 export const query = graphql`
   query HomeQuery {
@@ -45,4 +40,4 @@ export const query = graphql`
       internalId
     }
   }
-`
+`;


### PR DESCRIPTION
- [x] live content loading & no more manually hitting "refresh button" from GraphiQL playground
- [x] remove extra bundle to import story
- [x]  add `__refresh` in `useStoryblokBridge`
- [x] create Gatsby SDK ver. `useStoryblokBridge` & `useStoryblokState` -> `<StoryblokStory />` 
- [x] restructure code with story.tsx and common.ts