### PR TITLE
Adds the possibility to filter out datasources from being fetched in sourceNodes

### DIFF
--- a/lib/gatsby-node.js
+++ b/lib/gatsby-node.js
@@ -19,71 +19,88 @@ exports.sourceNodes = async function ({ actions, reporter }, options) {
     client,
   });
 
-	const languages = [];
-	if ("languages" in options) {
-		languages.push(...options.languages);
-	} else {
-		const space = await Sync.getSpace({ typePrefix: apiOptions.typePrefix });
-		languages.push(...space.language_codes);
-	}
+  const languages = [];
+  if ("languages" in options) {
+    languages.push(...options.languages);
+  } else {
+    const space = await Sync.getSpace({ typePrefix: apiOptions.typePrefix });
+    languages.push(...space.language_codes);
+  }
 
   for (const language of languages) {
     reporter.verbose(`Fetching stories for language "${language}"`);
-    await Sync.getAll('stories', {
-      node: 'StoryblokEntry',
-      params: getStoryParams(language, options),
-      typePrefix: options.typePrefix,
-      process: (item) => {
-        for (var prop in item.content) {
-          // eslint-disable-next-line no-prototype-builtins
-          if (!item.content.hasOwnProperty(prop) || ['_editable', '_uid'].indexOf(prop) > -1) {
-            continue;
+    try {
+      await Sync.getAll('stories', {
+        node: 'StoryblokEntry',
+        params: getStoryParams(language, options),
+        typePrefix: options.typePrefix,
+        process: (item) => {
+          for (var prop in item.content) {
+            // eslint-disable-next-line no-prototype-builtins
+            if (!item.content.hasOwnProperty(prop) || ['_editable', '_uid'].indexOf(prop) > -1) {
+              continue;
+            }
+            const objectType = Object.prototype.toString
+              .call(item.content[prop])
+              .replace('[object ', '')
+              .replace(']', '')
+              .toLowerCase();
+
+            if (['number', 'boolean', 'string'].indexOf(objectType) === -1) {
+              continue;
+            }
+
+            const type = prop == 'component' ? '' : '_' + objectType;
+
+            item['field_' + prop + type] = item.content[prop];
           }
-          const objectType = Object.prototype.toString
-            .call(item.content[prop])
-            .replace('[object ', '')
-            .replace(']', '')
-            .toLowerCase();
 
-          if (['number', 'boolean', 'string'].indexOf(objectType) === -1) {
-            continue;
-          }
-
-          const type = prop == 'component' ? '' : '_' + objectType;
-
-          item['field_' + prop + type] = item.content[prop];
-        }
-
-        item.content = stringify(item.content);
-      },
-    });
+          item.content = stringify(item.content);
+        },
+      });
+    }	catch (e) {
+      reporter.panic(`Failed to fetch stories for language "${language}"`, e);
+    }
   }
 
 
   if (options.includeTags !== false) {
     reporter.verbose('Fetching tags');
-    await Sync.getAll('tags', {
-      node: 'StoryblokTag',
-      params: getStoryParams('', options),
-      process: (item) => {
-        item.id = item.name;
-      },
-    });
+    try {
+      await Sync.getAll('tags', {
+        node: 'StoryblokTag',
+        params: getStoryParams('', options),
+        process: (item) => {
+          item.id = item.name;
+        },
+      });
+    } catch (e) {
+      reporter.panic('Failed to fetch tags', e);
+    }
   }
 
   if (options.includeLinks === true) {
     reporter.verbose('Fetching links');
-    await Sync.getAll('links', {
-      node: 'StoryblokLink',
-      params: getStoryParams('', options),
-    });
+    try {
+      await Sync.getAll('links', {
+        node: 'StoryblokLink',
+        params: getStoryParams('', options),
+      });
+    } catch (e) {
+      reporter.panic('Failed to fetch links', e);
+    }
   }
 
-  reporter.verbose('Fetching datasources');
-  const datasources = await Sync.getAll('datasources', {
-    node: 'StoryblokDatasource',
-    typePrefix: options.typePrefix,
-  });
+  let datasources = [];
+  try {
+    reporter.verbose('Fetching datasources');
+    datasources = await Sync.getAll('datasources', {
+      node: 'StoryblokDatasource',
+      typePrefix: options.typePrefix,
+    });
+  } catch (e) {
+    reporter.panic('Failed to fetch datasources', e);
+  }
 
   for (const datasource of datasources) {
     // If a datasource filter is set it acts as a whitelist and ignores all datasources not explicitly listed.
@@ -96,34 +113,42 @@ exports.sourceNodes = async function ({ actions, reporter }, options) {
 
     const datasourceSlug = datasource.slug;
 
-    await Sync.getAll('datasource_entries', {
-      node: 'StoryblokDatasourceEntry',
-      typePrefix: options.typePrefix,
-      params: {
-        datasource: datasourceSlug,
-      },
-      process: (item) => {
-        item.data_source_dimension = null;
-        item.data_source = datasourceSlug;
-      },
-    });
-
-    const datasourceDimensions = datasource.dimensions || [];
-
-    for (const dimension of datasourceDimensions) {
-      reporter.verbose(`Fetching datasource entries for datasource "${datasource.slug}" and dimension "${dimension.entry_value}"`);
+    try {
       await Sync.getAll('datasource_entries', {
         node: 'StoryblokDatasourceEntry',
         typePrefix: options.typePrefix,
         params: {
           datasource: datasourceSlug,
-          dimension: dimension.entry_value,
         },
         process: (item) => {
-          item.data_source_dimension = dimension.entry_value;
+          item.data_source_dimension = null;
           item.data_source = datasourceSlug;
         },
       });
+    } catch (e) {
+      reporter.panic(`Failed to fetch datasource entries for datasource "${datasource.slug}"`, e);
+    }
+
+    const datasourceDimensions = datasource.dimensions || [];
+
+    for (const dimension of datasourceDimensions) {
+      reporter.verbose(`Fetching datasource entries for datasource "${datasource.slug}" and dimension "${dimension.entry_value}"`);
+      try {
+        await Sync.getAll('datasource_entries', {
+          node: 'StoryblokDatasourceEntry',
+          typePrefix: options.typePrefix,
+          params: {
+            datasource: datasourceSlug,
+            dimension: dimension.entry_value,
+          },
+          process: (item) => {
+            item.data_source_dimension = dimension.entry_value;
+            item.data_source = datasourceSlug;
+          },
+        });
+      } catch (e) {
+        reporter.panic(`Failed to fetch datasource entries for datasource "${datasource.slug}" and dimension "${dimension.entry_value}"`, e);
+      }
     }
   }
 };

--- a/lib/gatsby-node.js
+++ b/lib/gatsby-node.js
@@ -74,6 +74,11 @@ exports.sourceNodes = async function ({ actions }, options) {
   });
 
   for (const datasource of datasources) {
+    // If a datasource filter is set it acts as a whitelist and ignores all datasources not explicitly listed.
+		if(options.datasourceFilter && options.datasourceFilter.length > 0 && !options.datasourceFilter.includes(datasource.slug)) {
+			continue;
+		}
+
     const datasourceSlug = datasource.slug;
 
     await Sync.getAll('datasource_entries', {

--- a/lib/gatsby-node.js
+++ b/lib/gatsby-node.js
@@ -75,9 +75,9 @@ exports.sourceNodes = async function ({ actions }, options) {
 
   for (const datasource of datasources) {
     // If a datasource filter is set it acts as a whitelist and ignores all datasources not explicitly listed.
-		if(options.datasourceFilter && options.datasourceFilter.length > 0 && !options.datasourceFilter.includes(datasource.slug)) {
-			continue;
-		}
+    if(options.datasourceFilter && options.datasourceFilter.length > 0 && !options.datasourceFilter.includes(datasource.slug)) {
+      continue;
+    }
 
     const datasourceSlug = datasource.slug;
 


### PR DESCRIPTION
If sites are deployed in a lot of different environments datasources might not always be relevant to fetch for each environment. In our project we hit a lot of rate limits with the Storyblok API due to datasource fetches in the source plugin. This change would greatly decrease our load on the API.