### PR TITLE
fix: mark package as deprecated in README and index.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+> [!WARNING]
+> **DEPRECATED**: This package is no longer maintained. We recommend considering Next.js or Remix as the new industry standards, used along with our [React SDK](https://github.com/storyblok/storyblok-react).
+
+
 <div align="center">
 	<a href="https://www.storyblok.com?utm_source=github.com&utm_medium=readme&utm_campaign=gatsby-source-storyblok" align="center">
 		<img src="https://a.storyblok.com/f/88751/1776x360/66e302b912/sb-gatsby-githero.png"  alt="Storyblok Logo">
@@ -8,6 +12,7 @@
   </p>
   <br />
 </div>
+
 
 <p align="center">
   <a href="https://www.npmjs.com/package/gatsby-source-storyblok">

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @deprecated This package is deprecated as Gatsby has been sunset. Please use our official Storyblok React SDK instead: https://github.com/storyblok/storyblok-react
+ */
+
 export {
   storyblokInit,
   apiPlugin,


### PR DESCRIPTION
- Added a deprecation warning in README.md, recommending Next.js or Remix as alternatives.
- Included a deprecation notice in index.ts, advising users to switch to the official Storyblok React SDK due to Gatsby's sunset.